### PR TITLE
prevent error if file is missing

### DIFF
--- a/src/InlineAssets.php
+++ b/src/InlineAssets.php
@@ -14,7 +14,12 @@ class InlineAssets extends Tags
             $this->params->get(['src', 'path'])
         );
 
-        $response = file_get_contents($asset);
+        try{
+            $response = file_get_contents($asset);
+        }
+        catch (\Exception $e){
+            return new HtmlString("");
+        }
 
         if ($this->params->bool('minify')) {
             $minifier = new Minify\JS($asset);
@@ -30,7 +35,12 @@ class InlineAssets extends Tags
             $this->params->get(['src', 'path'])
         );
 
-        $response = file_get_contents($asset);
+        try{
+            $response = file_get_contents($asset);
+        }
+        catch (\Exception $e){
+            return new HtmlString("");
+        }
 
         if ($this->params->bool('minify')) {
             $minifier = new Minify\CSS($asset);


### PR DESCRIPTION
I use this module for inlining critical CSS, which is only generated when in production mode. While developing the CSS file is missing and the module throws an error. To prevent this, I wrapped the file_get_contents into a try/catch.